### PR TITLE
namespace (Patchwork\) and convert to PSR-4 (fixes #11)

### DIFF
--- a/class/JSqueeze.php
+++ b/class/JSqueeze.php
@@ -8,6 +8,7 @@
  * GNU General Public License v2.0 (http://gnu.org/licenses/gpl-2.0.txt).
  */
 
+namespace Patchwork;
 
 /*
 *

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "php": ">=5.1.4"
     },
     "autoload": {
-        "psr-0": {
-            "JSqueeze": "class/"
+        "psr-4": {
+            "Patchwork\\": "class/"
         }
     }
 }

--- a/tests/JSqueeze/Tests/JSqueezeTest.php
+++ b/tests/JSqueeze/Tests/JSqueezeTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace JSqueeze\Tests;
+namespace Patchwork\JSqueeze\Tests;
 
-use JSqueeze;
+use \Patchwork\JSqueeze;
 
 class JSqueezeTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Previously JSqueeze claimed PSR-0 compliance in composer.json but was not in fact compliant, as PSR-0 requires at least one level of namespacing, bare classes are not PSR-0 compliant. As PSR-4 has now deprecated PSR-0, convert to PSR-4 while we're about it, which has the handy bonus of meaning the class file does not need to be moved at all.

This is an obvious BC break: all consumers have to switch from calling `new \JSqueeze()` to `new \Patchwork\JSqueeze()`.

My erstwhile colleague Remi Collet contends the namespace should be Patchwork\Jsqueeze , I don't really care, I just want to cry myself to sleep at this point.