### PR TITLE
Failing test case for continue with label

### DIFF
--- a/tests/expected/contiue_label.js
+++ b/tests/expected/contiue_label.js
@@ -1,0 +1,1 @@
+;lbl:for(i in j){if(j==1){continue lbl;x=1}};

--- a/tests/test/contiue_label.js
+++ b/tests/test/contiue_label.js
@@ -1,0 +1,6 @@
+lbl: for (i in j){
+    if(j==1){
+        continue lbl;
+        x =  1;
+    }
+}


### PR DESCRIPTION
```js
lbl: for (i in j){
    if(j==1){
        continue lbl;
        x =  1;
    }
}
```

the `lbl` label of continue is lost during the min process 