### PR TITLE
Fix for empty statement after `else` at end of block

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,7 @@ branches:
     - master
 
 install:
-  - >
-    composer install;
-    composer update --with-dependencies --prefer-stable --prefer-dist;
-    composer show;
+  - composer install
 
 script:
-  - phpunit --coverage-text
+  - composer ci:tests:unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@ branches:
     - master
 
 install:
-  - composer install
+  - >
+    composer install;
+    composer update --with-dependencies --prefer-stable --prefer-dist;
+    composer show;
 
 script:
   - phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=4.0 <6.0"
+    },
     "autoload": {
         "psr-4": {
             "Patchwork\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
             "Patchwork\\": "src/"
         }
     },
+    "scripts": {
+        "ci:tests:unit": "phpunit --coverage-text"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.0-dev"

--- a/src/JSqueeze.php
+++ b/src/JSqueeze.php
@@ -490,7 +490,7 @@ class JSqueeze
         $cc_on && $f = str_replace('@#3', "\r", $f);
 
         // Fix "else ;" empty instructions
-        $f = preg_replace("'(?<![\$.a-zA-Z0-9_])else\n'", "\n", $f);
+        $f = preg_replace("'(?<![\$.a-zA-Z0-9_])else([\n}])'", '$1', $f);
 
         $r1 = array( // keywords with a direct object
             'case','delete','do','else','function','in','instanceof','of','break',

--- a/tests/expected/if-empty-else.js
+++ b/tests/expected/if-empty-else.js
@@ -1,0 +1,1 @@
+;function f(n){if(n)return n;else{};if(n){return n}};function g(n){if(n){return n};if(n)return n;};function h(n){if(n)return n;;if(n)return n;};function i(n){if(n)return n;;if(n)return n;else{}};

--- a/tests/test/if-empty-else.js
+++ b/tests/test/if-empty-else.js
@@ -1,0 +1,36 @@
+function f(x) {
+  if (x)
+    return x;
+  else {
+  }
+  if (x) {
+    return x;
+  } else ;
+}
+function g(x) {
+  if (x) {
+    return x;
+  } else ;
+  if (x)
+    return x;
+  else ;
+}
+function h(x) {
+  if (x)
+    return x;
+  else ;
+  if (x)
+    return x;
+  else
+    ;
+}
+function i(x) {
+  if (x)
+    return x;
+  else
+    ;
+  if (x)
+    return x;
+  else {
+  }
+}


### PR DESCRIPTION
Remove any `else` which ends up with nothing following it at the end of a block, e.g. in
```
function f(x) {
  if (x)
    return x;
  else
    ;
}
```
Previously, the semicolon would be removed but not the `else` keyword, resulting in invalid code.  (This was only an issue at the end of a code block, i.e. immediately before a `}`.)