### PR TITLE
Fix for Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,7 @@ branches:
     - master
 
 install:
-  - >
-    composer install;
-    composer update --with-dependencies --prefer-stable --prefer-dist;
-    composer show;
+  - composer install
 
 script:
-  - phpunit --coverage-text
+  - composer ci:tests:unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@ branches:
     - master
 
 install:
-  - composer install
+  - >
+    composer install;
+    composer update --with-dependencies --prefer-stable --prefer-dist;
+    composer show;
 
 script:
   - phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=4.0 <6.0"
+    },
     "autoload": {
         "psr-4": {
             "Patchwork\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
             "Patchwork\\": "src/"
         }
     },
+    "scripts": {
+        "ci:tests:unit": "phpunit --coverage-text"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.0-dev"


### PR DESCRIPTION
- Removed PHP 5.3 from Travis CI build (PHP 5.3 is now supported only on Precise);
- Invoke `phpunit` via Composer so that PHPUnit no later than version 5.x is used with PHP 7.x (PHPUnit 6+ requires using namespaced `\PHPUnit\Framework\TestCase` class).