### PR TITLE
 Optimize final `str_replace` restoring strings 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,7 @@ branches:
     - master
 
 install:
-  - >
-    composer install;
-    composer update --with-dependencies --prefer-stable --prefer-dist;
-    composer show;
+  - composer install
 
 script:
-  - phpunit --coverage-text
+  - composer ci:tests:unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@ branches:
     - master
 
 install:
-  - composer install
+  - >
+    composer install;
+    composer update --with-dependencies --prefer-stable --prefer-dist;
+    composer show;
 
 script:
   - phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=4.0 <6.0"
+    },
     "autoload": {
         "psr-4": {
             "Patchwork\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
             "Patchwork\\": "src/"
         }
     },
+    "scripts": {
+        "ci:tests:unit": "phpunit --coverage-text"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.0-dev"

--- a/src/JSqueeze.php
+++ b/src/JSqueeze.php
@@ -166,7 +166,10 @@ class JSqueeze
         $code = substr($tree[$key]['code'], 1);
         $code = preg_replace("'\breturn !'", 'return!', $code);
         $code = preg_replace("'\}(?=(else|while)[^\$.a-zA-Z0-9_])'", "}\r", $code);
-        $code = str_replace(array_keys($this->strings), array_values($this->strings), $code);
+        // $code = str_replace(array_keys($this->strings), array_values($this->strings), $code);
+        // preg_replace is much more efficient than str_replace here
+        // because we don't need to scan the entire code each time for every replacement
+        $code = preg_replace_callback('#//\'\'""\\d++(?:/?+\'|\\])#', array($this, 'restoreString'), $code);
 
         if ($singleLine) {
             $code = strtr($code, "\n", ';');
@@ -1021,6 +1024,11 @@ class JSqueeze
         $s = str_replace('2#@', '//@', $s);
         $s = str_replace('1#@', '/*@', $s);
         $s = str_replace('##', '#', $s);
+    }
+
+    protected function restoreString($m)
+    {
+        return $this->strings[$m[0]];
     }
 
     private function rsort($array)


### PR DESCRIPTION
For a large source file (1Mb+) with a large number of strings (10,000+),
JSqueeze can take a long time to complete due to the inefficiency of
`str_replace` with multiple replacements (restoring the original JavaScript
strings and regular expressions in the code).

As the code only needs to be processed once to make all the string replacements,
`preg_replace` is much more efficient here.  In the case of a 5Mb source file
with 20,000 strings it is approx. 100x faster for the string replacements,
making squeezing about 8x faster overall.

Even for small files, this appears to be a performance improvement: the unit
tests seem to be taking about 5% less time.