### PR TITLE
fix squeezing for continue statement with label

### DIFF
--- a/src/JSqueeze.php
+++ b/src/JSqueeze.php
@@ -495,7 +495,7 @@ class JSqueeze
         $r1 = array( // keywords with a direct object
             'case','delete','do','else','function','in','instanceof','of','break',
             'new','return','throw','typeof','var','void','yield','let','if',
-            'const','get','set',
+            'const','get','set','continue',
         );
 
         $r2 = array( // keywords with a subject


### PR DESCRIPTION
Issue described here: https://github.com/tchwork/jsqueeze/issues/61